### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "./lib/lodash-snippets",
   "version": "1.1.1",
   "description": "Lo-Dash snippets for AtomEditor",
-  "activationEvents": [
-    "lodash-snippets:toggle"
-  ],
+  "activationCommands": {
+    "atom-workspace": ["lodash-snippets:toggle"]
+  },
   "repository": "https://github.com/richtmat/lodash-snippets",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Updated to use `activationCommands` for Atom 1.0 release in June. I did not test this change because I'm unsure how to test it.